### PR TITLE
updated kabuki 2 for sex specific papers correlations

### DIFF
--- a/notebooks/KMT2D_and_KDM6A/KDM6A_gpsea.ipynb
+++ b/notebooks/KMT2D_and_KDM6A/KDM6A_gpsea.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:15:57.948147Z",
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:15:57.950649Z",
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:16:09.906693Z",
@@ -102,7 +102,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Individuals Processed: 100%|██████████| 81/81 [00:14<00:00,  5.51individuals/s]\n",
+      "Individuals Processed: 100%|██████████| 81/81 [00:18<00:00,  4.48individuals/s]\n",
       "Validated under permissive policy\n",
       "Showing errors and warnings\n",
       "Phenopackets\n",
@@ -792,7 +792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:16:10.145339Z",
@@ -1107,13 +1107,13 @@
        "                </tr>\n",
        "            \n",
        "              <tr>\n",
-       "                <td class=\"lft\">SPLICE_ACCEPTOR_VARIANT</td>\n",
+       "                <td class=\"lft\">SPLICE_DONOR_VARIANT</td>\n",
        "                <td>6</td>\n",
        "               <td>6%</td>\n",
        "                </tr>\n",
        "            \n",
        "              <tr>\n",
-       "                <td class=\"lft\">SPLICE_DONOR_VARIANT</td>\n",
+       "                <td class=\"lft\">SPLICE_ACCEPTOR_VARIANT</td>\n",
        "                <td>6</td>\n",
        "               <td>6%</td>\n",
        "                </tr>\n",
@@ -1125,6 +1125,12 @@
        "                </tr>\n",
        "            \n",
        "              <tr>\n",
+       "                <td class=\"lft\">INFRAME_DELETION</td>\n",
+       "                <td>2</td>\n",
+       "               <td>2%</td>\n",
+       "                </tr>\n",
+       "            \n",
+       "              <tr>\n",
        "                <td class=\"lft\">CODING_SEQUENCE_VARIANT</td>\n",
        "                <td>2</td>\n",
        "               <td>2%</td>\n",
@@ -1132,12 +1138,6 @@
        "            \n",
        "              <tr>\n",
        "                <td class=\"lft\">SPLICE_DONOR_REGION_VARIANT</td>\n",
-       "                <td>2</td>\n",
-       "               <td>2%</td>\n",
-       "                </tr>\n",
-       "            \n",
-       "              <tr>\n",
-       "                <td class=\"lft\">INFRAME_DELETION</td>\n",
        "                <td>2</td>\n",
        "               <td>2%</td>\n",
        "                </tr>\n",
@@ -1169,10 +1169,10 @@
        "</html>"
       ],
       "text/plain": [
-       "<gpsea.view._report.HtmlGpseaReport at 0x12ef1fef0>"
+       "<gpsea.view._report.HtmlGpseaReport at 0x116e4e180>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1185,7 +1185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:16:11.857008Z",
@@ -1205,7 +1205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:16:12.097804Z",
@@ -1266,7 +1266,7 @@
     "    -> **Ectodermal dysplasia HP:0000968**\n",
     "\n",
     "Test for **Hypothesis from Wang et al (2024):**\n",
-    "- Moderate-to-severe intellectual disability (IQ<55) was found to be significantly more presenet in male individuals than female (p=0.003)\n",
+    "- Moderate-to-severe intellectual disability (IQ<55) was found to be significantly more present in male individuals than female (p=0.003)\n",
     "    -> **Intellectual disability 'HP:0001249' - all descendants**\n",
     "- Congenital heart defect was found to be significantly more present in male individuals than female (p=0.015)\n",
     "    -> Wang et al used 'Abnormal cardiovascular system morphology (HP:0030680), but is filtered out by MTC filter, right?\n",
@@ -1278,7 +1278,87 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(DefaultTermId(idx=2, value=HP_0001344),\n",
+       " DefaultTermId(idx=2, value=HP_0002474),\n",
+       " DefaultTermId(idx=2, value=HP_0011350),\n",
+       " DefaultTermId(idx=2, value=HP_0011346),\n",
+       " DefaultTermId(idx=2, value=HP_0011352),\n",
+       " DefaultTermId(idx=2, value=HP_0011351),\n",
+       " DefaultTermId(idx=2, value=HP_5200240),\n",
+       " DefaultTermId(idx=2, value=HP_0006863),\n",
+       " DefaultTermId(idx=2, value=HP_0010863),\n",
+       " DefaultTermId(idx=2, value=HP:0000750),\n",
+       " DefaultTermId(idx=2, value=HP_0011345))"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from gpsea.analysis.mtc_filter import SpecifiedTermsMtcFilter\n",
+    "\n",
+    "id_curie = \"HP:0000750\"  # Delayed speech and language development\n",
+    "id_and_descendants = {id_curie, }\n",
+    "id_and_descendants.update(hpo.graph.get_descendants(id_curie))\n",
+    "id_and_descendants_mtc_filter = SpecifiedTermsMtcFilter(\n",
+    "    terms_to_test=id_and_descendants,\n",
+    ")\n",
+    "id_and_descendants_mtc_filter.terms_to_test\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(DefaultTermId(idx=2, value=HP_0002187),\n",
+       " DefaultTermId(idx=2, value=HP_0002342),\n",
+       " DefaultTermId(idx=2, value=HP_0006889),\n",
+       " DefaultTermId(idx=2, value=HP_0006887),\n",
+       " DefaultTermId(idx=2, value=HP:0001249),\n",
+       " DefaultTermId(idx=2, value=HP_0010864),\n",
+       " DefaultTermId(idx=2, value=HP_0001256))"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from gpsea.analysis.mtc_filter import SpecifiedTermsMtcFilter\n",
+    "\n",
+    "id_curie = \"HP:0001249\"  # Intellectual disability\n",
+    "id_and_descendants = {id_curie, }\n",
+    "id_and_descendants.update(hpo.graph.get_descendants(id_curie))\n",
+    "id_and_descendants_mtc_filter = SpecifiedTermsMtcFilter(\n",
+    "    terms_to_test=id_and_descendants,\n",
+    ")\n",
+    "id_and_descendants_mtc_filter.terms_to_test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:16:12.165505Z",
@@ -1296,10 +1376,20 @@
     "specified_terms = SpecifiedTermsMtcFilter(\n",
     "    terms_to_test=(\n",
     "        \"HP:0001288\",  # Gait disturbance\n",
-    "        \"HP:0000750\",  # Delayed speech and language development\n",
+    "        \"HP:0000750\",  # Delayed speech and language development    \n",
     "        'HP:0001249',  # Atypical behavior \n",
     "        'HP:0000708',  # Ectodermal dysplasia\n",
-    "        'HP:0000968'   # Intellectual disability \n",
+    "        'HP:0000968',  # Intellectual disability \n",
+    "        # All Intellectual disability descendants:\n",
+    "        'HP:0002187', \n",
+    "        'HP:0002342',\n",
+    "        'HP:0006889',\n",
+    "        'HP:0006887',\n",
+    "        'HP:0001249',\n",
+    "        'HP:0010864',\n",
+    "        'HP:0001256',\n",
+    "        'HP:0045017',  # congenital malformation of the left heart\n",
+    "        'HP:0011723'   # congenital malformation of the right heart\n",
     "    )\n",
     ")\n",
     "\n",
@@ -1318,103 +1408,20 @@
     "\n",
     "analysis = HpoTermAnalysis(\n",
     "    count_statistic=count_statistic,\n",
-    "    mtc_filter=specified_terms,\n",
+    "    mtc_filter=specified_terms\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 52,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:16:17.891018Z",
      "start_time": "2024-10-26T11:16:12.184298Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<!DOCTYPE html>\n",
-       "<html lang=\"en\">\n",
-       "<head>\n",
-       "  <meta charset=\"utf-8\">\n",
-       "  <title>Cohort</title>\n",
-       "  <style>table {\n",
-       "    border-collapse: collapse;\n",
-       "    margin: 25px 0;\n",
-       "      font-size: 0.9em;\n",
-       "      font-family: sans-serif;\n",
-       "      min-width: 400px;\n",
-       "      box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);\n",
-       "  }\n",
-       "\n",
-       "\n",
-       "  th {\n",
-       "    background-color: #f2f2f2;\n",
-       "    border: 1px solid #dddddd;\n",
-       "    text-align: left;\n",
-       "    padding: 2px;\n",
-       "  }\n",
-       "\n",
-       "  tr {\n",
-       "    border: 1px solid #dddddd;\n",
-       "  }\n",
-       "\n",
-       "  td {\n",
-       "    padding: 2px;\n",
-       "    font-weight: bold;\n",
-       "  }\n",
-       "\n",
-       "  tr:nth-child(even) {\n",
-       "    background-color: #f2f2f2;\n",
-       "  }\n",
-       "\n",
-       "  .table td,tr {\n",
-       "    text-align: left;\n",
-       "}\n",
-       "\n",
-       ".table td:first-child, tr:first-child {\n",
-       "    text-align: left;\n",
-       "}\n",
-       "\n",
-       "  </style>\n",
-       "</head>\n",
-       "\n",
-       "<body>\n",
-       "  <h1>Phenotype testing report</h1>\n",
-       "  <p>Phenotype MTC filter: <em>Specified terms MTC filter</em></p>\n",
-       "  <p>Multiple testing correction: <em>fdr_bh</em></p>\n",
-       "  <p>Performed statistical tests for 2 out of the total of 347 HPO terms.</p>\n",
-       "    <table>\n",
-       "      <caption>Using <em>Specified terms MTC filter</em>, 345 term(s) were omitted from statistical analysis.</caption>\n",
-       "        <tbody>\n",
-       "          <tr>\n",
-       "            <th>Code</th>\n",
-       "            <th>Reason</th>\n",
-       "            <th>Count</th>\n",
-       "          </tr>\n",
-       "          \n",
-       "          <tr>\n",
-       "            <td>ST1</td>\n",
-       "            <td>Non-specified term</td>\n",
-       "            <td>345</td>\n",
-       "          </tr>\n",
-       "          \n",
-       "        </tbody>\n",
-       "    </table>\n",
-       "</body>\n",
-       "</html>"
-      ],
-      "text/plain": [
-       "<gpsea.view._report.HtmlGpseaReport at 0x13c06f290>"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from gpsea.analysis.predicate.genotype import sex_predicate\n",
     "from gpsea.view import MtcStatsViewer\n",
@@ -1431,7 +1438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 50,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:16:17.969272Z",
@@ -1476,13 +1483,13 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>Delayed speech and language development [HP:0000750]</th>\n",
-       "      <td>25/30</td>\n",
-       "      <td>83%</td>\n",
-       "      <td>29/29</td>\n",
-       "      <td>100%</td>\n",
-       "      <td>0.104371</td>\n",
-       "      <td>0.052186</td>\n",
+       "      <th>Intellectual disability, severe [HP:0010864]</th>\n",
+       "      <td>7/25</td>\n",
+       "      <td>28%</td>\n",
+       "      <td>14/18</td>\n",
+       "      <td>78%</td>\n",
+       "      <td>0.007772</td>\n",
+       "      <td>0.001943</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Intellectual disability [HP:0001249]</th>\n",
@@ -1490,31 +1497,48 @@
        "      <td>88%</td>\n",
        "      <td>23/23</td>\n",
        "      <td>100%</td>\n",
+       "      <td>0.263237</td>\n",
        "      <td>0.139822</td>\n",
-       "      <td>0.139822</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Intellectual disability, moderate [HP:0002342]</th>\n",
+       "      <td>7/25</td>\n",
+       "      <td>28%</td>\n",
+       "      <td>2/18</td>\n",
+       "      <td>11%</td>\n",
+       "      <td>0.263237</td>\n",
+       "      <td>0.263237</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Intellectual disability, mild [HP:0001256]</th>\n",
+       "      <td>7/25</td>\n",
+       "      <td>28%</td>\n",
+       "      <td>2/18</td>\n",
+       "      <td>11%</td>\n",
+       "      <td>0.263237</td>\n",
+       "      <td>0.263237</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "Sex of the individual                              FEMALE           MALE  \\\n",
-       "                                                    Count Percent  Count   \n",
-       "Delayed speech and language development [HP:000...  25/30     83%  29/29   \n",
-       "Intellectual disability [HP:0001249]                30/34     88%  23/23   \n",
+       "Sex of the individual                          FEMALE           MALE          \\\n",
+       "                                                Count Percent  Count Percent   \n",
+       "Intellectual disability, severe [HP:0010864]     7/25     28%  14/18     78%   \n",
+       "Intellectual disability [HP:0001249]            30/34     88%  23/23    100%   \n",
+       "Intellectual disability, moderate [HP:0002342]   7/25     28%   2/18     11%   \n",
+       "Intellectual disability, mild [HP:0001256]       7/25     28%   2/18     11%   \n",
        "\n",
-       "Sex of the individual                                                          \\\n",
-       "                                                   Percent Corrected p values   \n",
-       "Delayed speech and language development [HP:000...    100%           0.104371   \n",
-       "Intellectual disability [HP:0001249]                  100%           0.139822   \n",
-       "\n",
-       "Sex of the individual                                         \n",
-       "                                                    p values  \n",
-       "Delayed speech and language development [HP:000...  0.052186  \n",
-       "Intellectual disability [HP:0001249]                0.139822  "
+       "Sex of the individual                                                        \n",
+       "                                               Corrected p values  p values  \n",
+       "Intellectual disability, severe [HP:0010864]             0.007772  0.001943  \n",
+       "Intellectual disability [HP:0001249]                     0.263237  0.139822  \n",
+       "Intellectual disability, moderate [HP:0002342]           0.263237  0.263237  \n",
+       "Intellectual disability, mild [HP:0001256]               0.263237  0.263237  "
       ]
      },
-     "execution_count": 25,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1546,7 +1570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 28,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:16:23.695435Z",
@@ -1977,7 +2001,7 @@
        "Intellectual disability, severe [HP:0010864]        1.000000  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1986,6 +2010,11 @@
     "from gpsea.model import VariantEffect\n",
     "\n",
     "from gpsea.analysis.predicate.genotype import VariantPredicates, monoallelic_predicate\n",
+    "\n",
+    "analysis = HpoTermAnalysis(\n",
+    "    count_statistic=count_statistic,\n",
+    "    mtc_filter=mtc_filter\n",
+    ")\n",
     "\n",
     "missense = VariantPredicates.variant_effect(VariantEffect.FRAMESHIFT_VARIANT, mane_tx_id)\n",
     "missense_pred = monoallelic_predicate(a_predicate=missense,\n",
@@ -2004,7 +2033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 29,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:16:29.409038Z",
@@ -2435,7 +2464,7 @@
        "Intellectual disability, severe [HP:0010864]        1.000000  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2465,7 +2494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 31,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-26T11:16:35.160211Z",
@@ -2839,7 +2868,7 @@
        "Abnormal oral cavity morphology [HP:0000163]        1.000000  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Hey @pnrobinson,

I have updated the notebook for kabuki 2 to include the two papers in the intro, analysis, and the summary in the end. 

> Faundes V, . Clinical delineation, sex differences, and genotype-phenotype correlation in pathogenic KDM6A variants causing X-linked Kabuki syndrome type 2. Genet Med. 2021 Jul;23(7):1202-1210. doi: 10.1038/s41436-021-01119-8. Epub 2021 Mar 5. PMID: 33674768; PMCID: PMC8257478.
> 
> Wang Y, Xu Y, Chen Y, Hu Y, Li Q, Liu S, Wang J, Wang X. Sex-specific difference in phenotype of Kabuki syndrome type 2 patients: a matched case-control study. BMC Pediatr. 2024 Feb 19;24(1):133. doi: 10.1186/s12887-024-04562-z. PMID: 38373926; PMCID: PMC10875883.

Could you please check before merging whether I "deducted" the right phenotypes? Some of the phenotypes could not be included after the filtering step.