### PR TITLE
Smarcc2 finish

### DIFF
--- a/notebooks/SMARCC2/SMARCC2_gpc.ipynb
+++ b/notebooks/SMARCC2/SMARCC2_gpc.ipynb
@@ -14,7 +14,19 @@
     "> (\"Coffin-Siris syndrome type 8\" OR CSS8 OR \"Coffin-Siris syndrome 8\") AND (SMARCC2 OR \"SMARCC2 variants\" OR \"SMARCC2 mutations\") AND (\"genotype phenotype correlation\" OR \" phenotype genotype correlation\")\n",
     "\n",
     "\n",
-    "This query returned on article [PMID:34881817](https://pubmed.ncbi.nlm.nih.gov/34881817/), which reported on two individuals affected by CSS8 showing a similar clinical manifestations with two severe variants c.1824_1826del, p.(Leu609del) and  c.1094_1097delAGAA, p.(Lys365Thrfs*12)"
+    "This query returned on article [PMID:34881817](https://pubmed.ncbi.nlm.nih.gov/34881817/), which reported on two individuals affected by CSS8 showing a similar clinical manifestations with two severe variants c.1824_1826del, p.(Leu609del) and  c.1094_1097delAGAA, p.(Lys365Thrfs*12)\n",
+    "\n",
+    "Further we found the article: Elucidating the clinical and molecular spectrum of SMARCC2-associated NDD in a cohort of 65 affected individuals - Bosch E, et al (2023), [https://doi.org/10.1016/j.gim.2023.100950)], which reported on the following significant correlations between missense and truncating variants: \n",
+    "\n",
+    "**\"_p values missense versus truncating variant cohorts_\"** for \n",
+    " - Global developmental delay; Intellectual disability (HP:0001263;HP:0001249):          p = 0.005 (FDR-corr: 0.033)\n",
+    " - Muscular hypotonia (HP:0001252):                                                      p = 0.004 (FDR-corr: 0.033)\n",
+    " - mild GDD/ID (HP:0011342;HP:0001256):                                                  p = 0.012 (FDR-corr: 0.051)\n",
+    " - Abnormality of the outer ear (HP:0000356):                                            p = 0.013 (FDR-corr: 0.051)\n",
+    " - Decreased body weight (HP:0004325):                                                   p = 0.002 (FDR-corr: 0.024)\n",
+    " - Abnormality of the eye (HP:0000478):                                                  p = 0.000 (FDR-corr: 0.008)\n",
+    " - Short stature (HP:0004322):                                                           p = 0.006 (FDR-corr: 0.035)\n",
+    " - Feeding difficulties/failure to thrive (HP:0011968;HP:0001508)                        p = 0.013 (FDR-corr: 0.051)"
    ]
   },
   {


### PR DESCRIPTION
in regard to #28  the revision of the summary to compare the results to Bosch E et al. (2023): https://www.sciencedirect.com/science/article/pii/S1098360023009632 

@pnrobinson we could not reproduce the significant correlations for they found for "_p values missense versus truncating variant cohorts". In our analysis missense vs 'other' nothing significant was found. 

I created the summary GPSEA output based on GPSEA 0.7.1 and below I referred to the paper on reproduction of results or not. Please check the notebook - thank you! 